### PR TITLE
Make solc version dependent to target project's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 node_modules/
+*.DS_Store
+*.log

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "vscode-uri": "^3.0.3"
   },
   "devDependencies": {
+    "esbuild": "^0.14.38",
     "@openzeppelin/contracts": "^4.5.0",
     "@types/jasmine": "^3.10.3",
     "@types/node": "^17.0.21",

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -18,7 +18,14 @@ export function compile(document: TextDocument): SourceUnit[] {
     settings: { outputSelection: { "*": { "": ["ast"] } } },
   };
   const { remapping } = options;
-  const output = solc.compile(JSON.stringify(input), {
+  // Dynamically bind solc version based on project's dependency
+  let solcLocal;
+  try {
+    solcLocal = solc.setupMethods(require(rootPath + "/node_modules/solc/soljson.js"));
+  } catch (_) {
+    solcLocal = solc;
+  }
+  const output = solcLocal.compile(JSON.stringify(input), {
     import(path: string) {
       try {
         let absolutePath = path;


### PR DESCRIPTION
Resolves https://github.com/qiuxiang/coc-solidity/issues/6.
- ref: https://github.com/ethereum/solc-js#using-a-legacy-version