### PR TITLE
feat: support to go definition in monorepo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ configs.solidity = {
   default_config = {
     cmd = { 'solidity-ls', '--stdio' },
     filetypes = { 'solidity' },
-    root_dir = lspconfig.util.find_git_ancestor,
+    root_dir = lspconfig.util.root_pattern('package.json', '.git'),
     single_file_support = true,
   },
 }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process";
-import { accessSync } from "fs";
+import { accessSync, realpathSync } from "fs";
 import { join } from "path";
 import { SourceUnit } from "solidity-ast";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -81,7 +81,12 @@ export function getAbsolutePath(path: string) {
   try {
     accessSync(absolutePath);
   } catch (_) {
-    absolutePath = join(includePath, path);
+    try {
+      absolutePath = join(realpathSync("."), options.includePath, path)
+      accessSync(absolutePath);
+    } catch (_) {
+      absolutePath = join(includePath, path);
+    }
   }
   return absolutePath;
 }


### PR DESCRIPTION
So far, the solidity-ls does not support to go definition in monorepo. Because `workspaceFolders` returns the root path which contains `.git`, so consider the following case

```
ROOT
  |- .git
  |- eth
    |- hardhat-project
      |- node_modules
        |- hardhat
      |- contracts
        |- Token.sol
      |- package.json
```

The code like `import "hardhat/console.sol";` will go to `ROOT/node_modules/hardhat/console.sol` which does not exist.

The PR will fix this case. And it will navigate to `ROOT/eth/hardhat-project/node_modules/hardhat/console.sol`