### PR TITLE
Added support for passing --allow-paths to solc and documented in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,13 @@
 
 <img width="276" alt="image" src="https://user-images.githubusercontent.com/1709072/159026514-4d178c66-336c-46c3-b647-37d8ed048568.png"><img width="276" alt="image" src="https://user-images.githubusercontent.com/1709072/159026797-af4de669-49ff-4036-b6b0-0ea42a68a019.png"><img width="276" alt="image" src="https://user-images.githubusercontent.com/1709072/159030410-65a68fe6-bc77-45e2-aa8a-b305fbb01b17.png">
 
-**This language server has no tolerance.**
+This language server has no error tolerance.
 Means that some features will only work if sources are no syntax error.
 
 For example:
 
 ```solidity
-// completion not working due to missing semicolon
+// should not work
 msg.
    ^
 
@@ -85,16 +85,25 @@ npx solidity-ls --stdio
 
 ### neovim lsp
 
+More info: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#solidity
+
 ```lua
 local lspconfig = require 'lspconfig'
-local configs = require 'lspconfig.configs'
-configs.solidity = {
-  default_config = {
-    cmd = { 'solidity-ls', '--stdio' },
-    filetypes = { 'solidity' },
-    root_dir = lspconfig.util.find_git_ancestor,
-    single_file_support = true,
+lspconfig.solidity.setup({
+  -- on_attach = on_attach, -- probably you will need this.
+  -- capabilities = capabilities,
+  settings = {
+    -- example of global remapping
+    solidity = {
+        includePath = '',
+        remapping = { ["@OpenZeppelin/"] = 'OpenZeppelin/openzeppelin-contracts@4.6.0/' },
+        -- Array of paths to pass as --allow-paths to solc
+        allowPaths = {}
+    }
   },
-}
-lspconfig.solidity.setup {}
+})
 ```
+
+### foundry supports
+
+run `forge remappings > remappings.txt` in project root.

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -20,6 +20,8 @@ export function compile(document: TextDocument): Promise<any> {
       rootPath,
       "--include-path",
       options.includePath,
+      "--allow-paths",
+      options.allowPaths.join(","),
     ]);
 
     let stdout = "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,14 @@ import { onRename } from "./rename";
 import { onSignatureHelp } from "./signature-help";
 import { Solidity } from "./solidity";
 
+export let rootPath = realpathSync(".");
+
 export const options = {
   includePath: "node_modules",
   remapping: <Record<string, string>>{},
+  allowPaths: [rootPath],
 };
-export let rootPath = realpathSync(".");
+
 export let connection: Connection;
 export let documents: TextDocuments<TextDocument>;
 export const solidityMap = new Map<string, Solidity>();
@@ -47,12 +50,15 @@ export function createServer(
   connection.onSignatureHelp(onSignatureHelp);
 
   connection.onDidChangeConfiguration(({ settings: { solidity } }) => {
-    const { includePath, remapping } = solidity ?? {};
+    const { includePath, remapping, allowPaths } = solidity ?? {};
     if (includePath) {
       options.includePath = includePath;
     }
     if (remapping) {
       options.remapping = Object.assign(options.remapping, remapping);
+    }
+    if (allowPaths && Array.isArray(allowPaths)) {
+      options.allowPaths = options.allowPaths.concat(allowPaths);
     }
   });
 


### PR DESCRIPTION
Exposing `--allow-paths` as a config for the underlying `solc` call. 

In my case, I'm running a pnpm monorepo with `packages/blockchain` as my blockchain folder. Because of how pnpm works, it hoists the packages up to the root directory, resulting in `ParserError: Source "@openzeppelin/contracts/..." not found: File outside of allowed directories. The following are allowed: "/...".`

With this config I can pass the git root as an allowed path, fixing this issue

Edit: I suspect this also fixes #8 , as the video below shows. I'm able to jump to definition no problem.
In my config I'm using `allowPaths = { vim.fs.dirname(vim.fs.find({".git"}, { upward = true })[1]) }`

https://github.com/qiuxiang/solidity-ls/assets/30100875/3acb3331-7bbb-401f-827b-830029a9e810

